### PR TITLE
Use .toggleStyle instead of a brand new toggle

### DIFF
--- a/Sources/LabeledToggle/LabeledToggle.swift
+++ b/Sources/LabeledToggle/LabeledToggle.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS, deprecated: 16.0, message: "use .toggleStyle(.labeled(...)) instead")
 public struct LabeledToggle: View {
     @Binding private var isEnabled: Bool
     private let systemNames: (left: String, right: String)

--- a/Sources/LabeledToggle/LabeledToggle.swift
+++ b/Sources/LabeledToggle/LabeledToggle.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@available(iOS, deprecated: 16.0, message: "use .toggleStyle(.labeled(...)) instead")
+@available(*, deprecated, message: "use .toggleStyle(.labeled(...)) instead")
 public struct LabeledToggle: View {
     @Binding private var isEnabled: Bool
     private let systemNames: (left: String, right: String)

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -82,7 +82,6 @@ extension ToggleStyle where Self == LabeledToggleStyle {
                 .toggleStyle(.labeled(off: "heart", on: "heart.fill"))
                 .tint(.brown)
                 .foregroundStyle(.red)
-                .toggleStyle(.button)
             }
             .padding(40)
             .background(.ultraThinMaterial)

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 16, *)
 public struct LabeledToggleStyle: ToggleStyle {
     private let on, off: String
     @State private var isPressing: Bool = false
@@ -14,12 +13,6 @@ public struct LabeledToggleStyle: ToggleStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         Toggle(configuration)
-            .onAppear {
-                isPressing = configuration.isMixed
-            }
-            .onChange(of: configuration.isMixed) { newValue in
-                isPressing = newValue
-            }
             .contentShape(.rect)
             .labelsHidden()
             .background(
@@ -70,7 +63,6 @@ public struct LabeledToggleStyle: ToggleStyle {
     }
 }
 
-@available(iOS 16, *)
 extension ToggleStyle where Self == LabeledToggleStyle {
     public static func labeled(off: String, on: String) -> Self {
         LabeledToggleStyle(off: off, on: on)

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+@available(iOS 16, *)
+public struct LabeledToggleStyle: ToggleStyle {
+    @State private var isEnabled: Bool = false
+    private let systemNames: (left: String, right: String)
+    @State private var isPressing: Bool = false
+    @State private var viewWidth: CGFloat = 0
+    @State private var isRightSide: Bool = false
+
+    public init(systemNames: (left: String, right: String)) {
+        self.systemNames = systemNames
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        Toggle(configuration)
+            .onAppear {
+                isEnabled = configuration.isOn
+                isPressing = configuration.isMixed
+            }
+            .onChange(of: configuration.isOn) { newValue in
+                isEnabled = newValue
+            }
+            .onChange(of: configuration.isMixed) { newValue in
+                isPressing = newValue
+            }
+            .contentShape(.rect)
+            .labelsHidden()
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { viewWidth = geo.size.width }
+                        .onChange(of: geo.size.width) { newWidth in
+                            viewWidth = newWidth
+                        }
+                }
+            )
+            .overlay {
+                Image(systemName: systemName())
+                    .offset(x: offset())
+                    .animation(.linear.speed(3), value: isPressing)
+                    .animation(.linear.speed(3), value: isRightSide)
+                    .allowsHitTesting(false)
+            }
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                    .onChanged { value in
+                        if !isPressing { isPressing = true }
+                        let x = value.location.x
+                        let width = max(viewWidth, 1)
+                        isRightSide = x > width / 2
+                    }
+                    .onEnded { _ in
+                        isPressing = false
+                        isRightSide = false
+                    }
+            )
+    }
+
+    private func offset() -> CGFloat {
+        if isPressing && isRightSide || isEnabled && !isPressing {
+            return 13
+        } else {
+            return -11
+        }
+    }
+
+    private func systemName() -> String {
+        if isPressing && isRightSide || isEnabled && !isPressing{
+            return systemNames.right
+        } else {
+            return systemNames.left
+        }
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    @Previewable @State var isEnabled: Bool = true
+
+    Toggle("Do You Like Coffee", isOn: $isEnabled)
+        .font(.title3)
+        .toggleStyle(LabeledToggleStyle(systemNames: ("heart", "heart.fill")))
+        .tint(.brown)
+        .foregroundStyle(.red)
+        .padding(40)
+        .background(.ultraThinMaterial)
+        .frame(maxHeight: .infinity)
+}

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -74,12 +74,16 @@ extension ToggleStyle where Self == LabeledToggleStyle {
 #Preview {
     @Previewable @State var isEnabled: Bool = true
 
-    Toggle("Do You Like Coffee", isOn: $isEnabled)
-        .font(.title3)
+    HStack {
+        Text("Do you like coffee?")
+            .font(.title3)
+        Spacer()
+        Toggle("Do You Like Coffee", isOn: $isEnabled)
         .toggleStyle(.labeled(off: "heart", on: "heart.fill"))
         .tint(.brown)
         .foregroundStyle(.red)
-        .padding(40)
-        .background(.ultraThinMaterial)
-        .frame(maxHeight: .infinity)
+    }
+    .padding(40)
+    .background(.ultraThinMaterial)
+    .frame(maxHeight: .infinity)
 }

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -13,6 +13,7 @@ public struct LabeledToggleStyle: ToggleStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         Toggle(configuration)
+            .toggleStyle(.switch)
             .contentShape(.rect)
             .labelsHidden()
             .background(

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -47,11 +47,23 @@ public struct LabeledToggleStyle: ToggleStyle {
             )
     }
 
+    private let rightOffset: CGFloat = if #available(iOS 26, *) {
+        13
+    } else {
+        11.4
+    }
+
+    private let leftOffset: CGFloat = if #available(iOS 26, *) {
+        -11
+    } else {
+        -9.4
+    }
+
     private func offset(for configuration: Configuration) -> CGFloat {
         if isPressing && isRightSide || configuration.isOn && !isPressing {
-            return 13
+            return rightOffset
         } else {
-            return -11
+            return leftOffset
         }
     }
 

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -3,13 +3,14 @@ import SwiftUI
 @available(iOS 16, *)
 public struct LabeledToggleStyle: ToggleStyle {
     @State private var isEnabled: Bool = false
-    private let systemNames: (left: String, right: String)
+    private let on, off: String
     @State private var isPressing: Bool = false
     @State private var viewWidth: CGFloat = 0
     @State private var isRightSide: Bool = false
 
-    public init(systemNames: (left: String, right: String)) {
-        self.systemNames = systemNames
+    public init(off: String, on: String) {
+        self.off = off
+        self.on = on
     }
 
     public func makeBody(configuration: Configuration) -> some View {
@@ -67,17 +68,17 @@ public struct LabeledToggleStyle: ToggleStyle {
 
     private func systemName() -> String {
         if isPressing && isRightSide || isEnabled && !isPressing{
-            return systemNames.right
+            return on
         } else {
-            return systemNames.left
+            return off
         }
     }
 }
 
 @available(iOS 16, *)
 extension ToggleStyle where Self == LabeledToggleStyle {
-    public static func labeled(systemNames: (left: String, right: String)) -> Self {
-        LabeledToggleStyle(systemNames: systemNames)
+    public static func labeled(off: String, on: String) -> Self {
+        LabeledToggleStyle(off: off, on: on)
     }
 }
 
@@ -87,7 +88,7 @@ extension ToggleStyle where Self == LabeledToggleStyle {
 
     Toggle("Do You Like Coffee", isOn: $isEnabled)
         .font(.title3)
-        .toggleStyle(.labeled(systemNames: ("heart", "heart.fill")))
+        .toggleStyle(.labeled(off: "heart", on: "heart.fill"))
         .tint(.brown)
         .foregroundStyle(.red)
         .padding(40)

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 @available(iOS 16, *)
 public struct LabeledToggleStyle: ToggleStyle {
-    @State private var isEnabled: Bool = false
     private let on, off: String
     @State private var isPressing: Bool = false
     @State private var viewWidth: CGFloat = 0
@@ -16,11 +15,7 @@ public struct LabeledToggleStyle: ToggleStyle {
     public func makeBody(configuration: Configuration) -> some View {
         Toggle(configuration)
             .onAppear {
-                isEnabled = configuration.isOn
                 isPressing = configuration.isMixed
-            }
-            .onChange(of: configuration.isOn) { newValue in
-                isEnabled = newValue
             }
             .onChange(of: configuration.isMixed) { newValue in
                 isPressing = newValue
@@ -37,8 +32,8 @@ public struct LabeledToggleStyle: ToggleStyle {
                 }
             )
             .overlay {
-                Image(systemName: systemName())
-                    .offset(x: offset())
+                Image(systemName: systemName(for: configuration))
+                    .offset(x: offset(for: configuration))
                     .animation(.linear.speed(3), value: isPressing)
                     .animation(.linear.speed(3), value: isRightSide)
                     .allowsHitTesting(false)
@@ -58,16 +53,16 @@ public struct LabeledToggleStyle: ToggleStyle {
             )
     }
 
-    private func offset() -> CGFloat {
-        if isPressing && isRightSide || isEnabled && !isPressing {
+    private func offset(for configuration: Configuration) -> CGFloat {
+        if isPressing && isRightSide || configuration.isOn && !isPressing {
             return 13
         } else {
             return -11
         }
     }
 
-    private func systemName() -> String {
-        if isPressing && isRightSide || isEnabled && !isPressing{
+    private func systemName(for configuration: Configuration) -> String {
+        if isPressing && isRightSide || configuration.isOn && !isPressing{
             return on
         } else {
             return off

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -70,20 +70,24 @@ extension ToggleStyle where Self == LabeledToggleStyle {
     }
 }
 
-@available(iOS 17, *)
 #Preview {
-    @Previewable @State var isEnabled: Bool = true
-
-    HStack {
-        Text("Do you like coffee?")
-            .font(.title3)
-        Spacer()
-        Toggle("Do You Like Coffee", isOn: $isEnabled)
-        .toggleStyle(.labeled(off: "heart", on: "heart.fill"))
-        .tint(.brown)
-        .foregroundStyle(.red)
+    struct Demo: View {
+        @State private var isEnabled: Bool = true
+        var body: some View {
+            HStack {
+                Text("Do you like coffee?")
+                    .font(.title3)
+                Spacer()
+                Toggle("Do You Like Coffee", isOn: $isEnabled)
+                .toggleStyle(.labeled(off: "heart", on: "heart.fill"))
+                .tint(.brown)
+                .foregroundStyle(.red)
+                .toggleStyle(.button)
+            }
+            .padding(40)
+            .background(.ultraThinMaterial)
+            .frame(maxHeight: .infinity)
+        }
     }
-    .padding(40)
-    .background(.ultraThinMaterial)
-    .frame(maxHeight: .infinity)
+    return Demo()
 }

--- a/Sources/LabeledToggle/LabeledToggleStyle.swift
+++ b/Sources/LabeledToggle/LabeledToggleStyle.swift
@@ -74,13 +74,20 @@ public struct LabeledToggleStyle: ToggleStyle {
     }
 }
 
+@available(iOS 16, *)
+extension ToggleStyle where Self == LabeledToggleStyle {
+    public static func labeled(systemNames: (left: String, right: String)) -> Self {
+        LabeledToggleStyle(systemNames: systemNames)
+    }
+}
+
 @available(iOS 17, *)
 #Preview {
     @Previewable @State var isEnabled: Bool = true
 
     Toggle("Do You Like Coffee", isOn: $isEnabled)
         .font(.title3)
-        .toggleStyle(LabeledToggleStyle(systemNames: ("heart", "heart.fill")))
+        .toggleStyle(.labeled(systemNames: ("heart", "heart.fill")))
         .tint(.brown)
         .foregroundStyle(.red)
         .padding(40)


### PR DESCRIPTION
It is recommended to make a style object for styling existing views instead of wrapping them in to a brand new view. So I have converted you code to a `toggleStyle` with some minor modifications but with the exact same output.
