### PR TITLE
feat: add correct offset for iOS pre26

### DIFF
--- a/Sources/LabeledToggle/LabeledToggle.swift
+++ b/Sources/LabeledToggle/LabeledToggle.swift
@@ -50,11 +50,23 @@ public struct LabeledToggle: View {
             )
     }
     
+    private let rightOffset: CGFloat = if #available(iOS 26, *) {
+        13
+    } else {
+        11.4
+    }
+
+    private let leftOffset: CGFloat = if #available(iOS 26, *) {
+        -11
+    } else {
+        -9.4
+    }
+
     private func offset() -> CGFloat {
         if isPressing && isRightSide || isEnabled && !isPressing {
-            return 13
+            return rightOffset
         } else {
-            return -11
+            return leftOffset
         }
     }
     


### PR DESCRIPTION
The hardcoded values does not work for iOS pre26 (tested on iOS 18)

Before:
<img width="1125" height="333" alt="image" src="https://github.com/user-attachments/assets/68a9c4c9-2661-459f-9ca2-dc51eddfdaec" />

After:
<img width="1125" height="332" alt="image" src="https://github.com/user-attachments/assets/2dd00e1a-a8a7-41c8-bf3b-4cb0187626e8" />
